### PR TITLE
修复api_batch_inpaint功能变量解构异常的问题

### DIFF
--- a/iopaint-change/api.py
+++ b/iopaint-change/api.py
@@ -277,8 +277,8 @@ class Api:
         return GenInfoResponse(prompt=prompt, negative_prompt=negative_prompt)
 
     def api_inpaint(self, req: InpaintRequest):
-        image, alpha_channel, infos = decode_base64_to_image(req.image)
-        mask, _, _ = decode_base64_to_image(req.mask, gray=True)
+        image, alpha_channel, infos, _ = decode_base64_to_image(req.image)
+        mask, _, _, _ = decode_base64_to_image(req.mask, gray=True)
 
         mask = cv2.threshold(mask, 127, 255, cv2.THRESH_BINARY)[1]
         if image.shape[:2] != mask.shape[:2]:
@@ -288,7 +288,7 @@ class Api:
             )
 
         if req.paint_by_example_example_image:
-            paint_by_example_image, _, _ = decode_base64_to_image(
+            paint_by_example_image, _, _, _ = decode_base64_to_image(
                 req.paint_by_example_example_image
             )
 
@@ -324,7 +324,7 @@ class Api:
             raise HTTPException(
                 status_code=422, detail="Plugin does not support output image"
             )
-        rgb_np_img, alpha_channel, infos = decode_base64_to_image(req.image)
+        rgb_np_img, alpha_channel, infos, _ = decode_base64_to_image(req.image)
         bgr_or_rgba_np_img = self.plugins[req.name].gen_image(rgb_np_img, req)
         torch_gc()
 
@@ -351,7 +351,7 @@ class Api:
             raise HTTPException(
                 status_code=422, detail="Plugin does not support output image"
             )
-        rgb_np_img, alpha_channel, infos = decode_base64_to_image(req.image)
+        rgb_np_img, alpha_channel, infos, _ = decode_base64_to_image(req.image)
         bgr_or_gray_mask = self.plugins[req.name].gen_mask(rgb_np_img, req)
         torch_gc()
         res_mask = gen_frontend_mask(bgr_or_gray_mask)
@@ -364,7 +364,7 @@ class Api:
         return [member.value for member in SDSampler.__members__.values()]
 
     def api_adjust_mask(self, req: AdjustMaskRequest):
-        mask, _, _ = decode_base64_to_image(req.mask, gray=True)
+        mask, _, _, _ = decode_base64_to_image(req.mask, gray=True)
         mask = adjust_mask(mask, req.kernel_size, req.operate)
         return Response(content=numpy_to_bytes(mask, "png"), media_type="image/png")
 
@@ -443,7 +443,7 @@ class Api:
         for i, (image_b64, mask_b64) in enumerate(zip(req.images, req.masks)):
             try:
                 # 解码图像和蒙版
-                image, alpha_channel, infos = decode_base64_to_image(image_b64)
+                image, alpha_channel, infos, _ = decode_base64_to_image(image_b64)
                 
                 # 处理蒙版，支持透明PNG
                 mask_data = base64.b64decode(mask_b64)


### PR DESCRIPTION
使用最新版本的iopaint，去水印功能异常，提示如下错误：

 ```
2025-03-28 22:38:55.120 | ERROR    | iopaint.api:api_batch_inpaint:504 - Error processing image 0: too many values to unpack (expected 3)
2025-03-28 22:38:55.120 | INFO     | iopaint.api:api_batch_inpaint:512 - Batch processing completed in 0.03s for 1 images
INFO:     127.0.0.1:64490 - "POST /api/v1/batch_inpaint HTTP/1.1" 200 OK
Traceback (most recent call last):
  File "D:\tools\IOPaint\iopaint\api.py", line 446, in api_batch_inpaint
    image, alpha_channel, infos = decode_base64_to_image(image_b64)
ValueError: too many values to unpack (expected 3)
```