### PR TITLE
fix: 简化默认模型选项并添加后端项目路径配置

### DIFF
--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -24,6 +24,8 @@ const DEFAULT_CONFIG = {
     backendPort: 8080,
     launchMode: "cuda", // 'cuda' | 'cpu'
     modelPath: "",
+    backendProjectPath: "",
+    defaultModel: "lama",
   },
   fileManagement: {
     downloadPath: "",
@@ -144,6 +146,9 @@ function createDefaultConfig() {
       "hub",
       "checkpoints"
     );
+    const appDir = path.dirname(app.getAppPath());
+    DEFAULT_CONFIG.general.backendProjectPath = path.join(appDir, "IOPaint");
+    DEFAULT_CONFIG.general.defaultModel = "lama";
     fs.writeFileSync(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2));
     globalConfig = { ...DEFAULT_CONFIG };
 
@@ -692,7 +697,6 @@ ipcMain.handle("check-project", async (event, selectPath) => {
       // 检查同级目录下的 IOPaint 文件夹
       const appDir = path.dirname(app.getAppPath());
       const iopaintPath = path.join(appDir, "IOPaint");
-      console.log(iopaintPath);
       if (fs.existsSync(iopaintPath)) {
         checkPath = iopaintPath;
       } else {

--- a/src/components/GlobalSettings.vue
+++ b/src/components/GlobalSettings.vue
@@ -83,7 +83,7 @@
               <q-select
                 v-model="localConfig.general.defaultModel"
                 label="默认模型"
-                :options="['lama', 'big-lama', 'ldm', 'zits', 'mat', 'fcf']"
+                :options="['lama']"
               />
             </div>
           </q-tab-panel>


### PR DESCRIPTION
移除全局设置中多余的模型选项，仅保留'lama'作为默认模型
在electron主进程中添加backendProjectPath配置项并设置默认值
同时移除调试用的console.log语句